### PR TITLE
bhr-client-exabgp-loop: improve compatibility with dash

### DIFF
--- a/scripts/bhr-client-exabgp-loop
+++ b/scripts/bhr-client-exabgp-loop
@@ -3,7 +3,7 @@
 # from the exabgp examples:
 # ignore Control C
 # if the user ^C exabgp we will get that signal too, ignore it and let exabgp send us a SIGTERM
-trap '' SIGINT
+trap '' INT
 
 sleep 1
 bhr-client-exabgp-process backfill || exit 1


### PR DESCRIPTION
On Ubuntu, /bin/sh is (by default) symlinked to dash.  Dash implements
the base POSIX standard [1] for this which only requires support for the
bare signal names (no SIG prefix).  Using the bare signal name without
a prefix should be supported on all POSIX shells.

[1] https://www.unix.com/man-page/POSIX/1posix/trap/